### PR TITLE
Cam dep slice sort

### DIFF
--- a/src/test/kotlin/microscenery/example/microscope/DemoHWScene.kt
+++ b/src/test/kotlin/microscenery/example/microscope/DemoHWScene.kt
@@ -45,12 +45,11 @@ class DemoHWScene : DefaultScene(withSwingUI = true) {
                 hw.hardwareDimensions().stageMax.x,
                 stageSpaceManager
             )
-            db.fixedStack(Vector3f(100f,100f,000f), Vector3f(100f, 100f,200f))
+            //db.fixedStack(Vector3f(100f,100f,000f), Vector3f(100f, 100f,200f))
             //Thread.sleep(2500)
-            db.randomStatic()
-
+            //db.randomStatic()
             db.fixed()
-            db.fixedStack()
+            //db.fixedStack()
 
             //stageSpaceManager.sampleStageSpace(Vector3f(25f), Vector3f(175f), Vector3f(30f, 30f, 50f))
         }


### PR DESCRIPTION
Added solution for issue #11  -> Slices get rendered when camera moves and Setting 'Stage.CameraDependendZSorting' is set to true.
Sorting by calculating the distance between the slice and the camera -> the furthest is added first->rendered first.