### PR TITLE
Added crude Vector support in Settings(Editor)

### DIFF
--- a/core/src/main/kotlin/fromScenery/Settings.kt
+++ b/core/src/main/kotlin/fromScenery/Settings.kt
@@ -73,59 +73,6 @@ class Settings(val prefix : String = "scenery.", inputPropertiesStream : InputSt
     }
 
     /**
-     * Parses the type from the incoming string, returns the casted value
-     */
-    fun parseType(value : String): Any = when {
-        value.lowercase() == "false" || value.lowercase() == "true" -> value.toBoolean()
-        value.contains("(") && value.contains(")") -> makeVector(value.replace("(", "").replace(")", ""))
-        value.lowercase().contains(".") && value.lowercase().toFloatOrNull() != null -> value.lowercase().toFloat()
-        value.lowercase().contains("f") && value.lowercase().replace("f", "").toFloatOrNull() != null -> value.lowercase().replace("f", "").toFloat()
-        value.lowercase().contains(".") && value.lowercase().contains("f") && value.lowercase().replace("f", "").toFloatOrNull() != null -> value.lowercase().replace("f", "").toFloat()
-        value.lowercase().contains("l") && value.lowercase().replace("l", "").toLongOrNull() != null -> value.lowercase().replace("l", "").toLong()
-        value.toIntOrNull() != null -> value.toInt()
-        else -> value
-    }
-
-    private fun makeVector(value : String) : Any {
-        val snippets = value.trim().split(",".toRegex()).toTypedArray()
-
-        var allFloats = true
-        snippets.forEachIndexed { i, it ->
-            snippets[i].trim()
-            allFloats = allFloats && checkType(parseType(it), listOf("Float", "Double", "Integer", "Long"))
-            if(!allFloats)
-                throw NumberFormatException("Wrong type inserted at index $i")
-        }
-        when (snippets.size) {
-            2 ->
-            {
-                return Vector2f(snippets[0].toFloat(), snippets[1].toFloat())
-            }
-            3 ->
-            {
-                return Vector3f(snippets[0].toFloat(), snippets[1].toFloat(), snippets[2].toFloat())
-            }
-            4 ->
-            {
-                return Vector4f(snippets[0].toFloat(), snippets[1].toFloat(), snippets[2].toFloat(), snippets[3].toFloat())
-            }
-            else ->
-            {
-                throw IllegalArgumentException("Too little or too many arguments!")
-            }
-        }
-
-    }
-
-    private fun checkType(first : Any, seconds : List<String>) : Boolean {
-        seconds.forEach {
-            if(first::class.java.typeName == "java.lang.$it")
-                return true
-        }
-        return false
-    }
-
-    /**
      * Query the settings store for a setting [name] and type T
      *
      * @param[name] The name of the setting
@@ -259,5 +206,59 @@ class Settings(val prefix : String = "scenery.", inputPropertiesStream : InputSt
      */
     fun getAllSettings(): List<String> {
         return settingsStore.keys().toList()
+    }
+
+    companion object {
+        private fun checkType(first : Any, seconds : List<String>) : Boolean {
+            seconds.forEach {
+                if(first::class.java.typeName == "java.lang.$it")
+                    return true
+            }
+            return false
+        }
+
+        private fun makeVector(value : String) : Any {
+            val snippets = value.trim().split(",".toRegex()).toTypedArray()
+    
+            var allFloats = true
+            snippets.forEachIndexed { i, it ->
+                allFloats = allFloats && checkType(parseType(it), listOf("Float", "Double", "Integer", "Long"))
+                if(!allFloats)
+                    throw NumberFormatException("Wrong type inserted at index $i")
+            }
+            when (snippets.size) {
+                2 ->
+                {
+                    return Vector2f(snippets[0].toFloat(), snippets[1].toFloat())
+                }
+                3 ->
+                {
+                    return Vector3f(snippets[0].toFloat(), snippets[1].toFloat(), snippets[2].toFloat())
+                }
+                4 ->
+                {
+                    return Vector4f(snippets[0].toFloat(), snippets[1].toFloat(), snippets[2].toFloat(), snippets[3].toFloat())
+                }
+                else ->
+                {
+                    throw IllegalArgumentException("Too little or too many arguments!")
+                }
+            }
+    
+        }
+
+        /**
+         * Parses the type from the incoming string, returns the casted value
+         */
+        fun parseType(value : String): Any = when {
+            value.lowercase() == "false" || value.lowercase() == "true" -> value.toBoolean()
+            value.contains("(") && value.contains(")") -> makeVector(value.replace("(", "").replace(")", "").replace(" ", ""))
+            value.lowercase().contains(".") && value.lowercase().toFloatOrNull() != null -> value.lowercase().toFloat()
+            value.lowercase().contains("f") && value.lowercase().replace("f", "").toFloatOrNull() != null -> value.lowercase().replace("f", "").toFloat()
+            value.lowercase().contains(".") && value.lowercase().contains("f") && value.lowercase().replace("f", "").toFloatOrNull() != null -> value.lowercase().replace("f", "").toFloat()
+            value.lowercase().contains("l") && value.lowercase().replace("l", "").toLongOrNull() != null -> value.lowercase().replace("l", "").toLong()
+            value.toIntOrNull() != null -> value.toInt()
+            else -> value
+        }
     }
 }

--- a/core/src/main/kotlin/fromScenery/SettingsEditor.kt
+++ b/core/src/main/kotlin/fromScenery/SettingsEditor.kt
@@ -78,7 +78,7 @@ class SettingsEditor @JvmOverloads constructor(var settings : Settings, private 
                 {
 
                     val castValue = try {
-                        settings.parseType(addValuefield.text)
+                        Settings.parseType(addValuefield.text)
                     } catch (e: IllegalArgumentException) {
                         addValuefield.text = null
                         JOptionPane.showMessageDialog(mainFrame, e.message, "Type Error", JOptionPane.ERROR_MESSAGE)
@@ -235,7 +235,7 @@ class SettingsEditor @JvmOverloads constructor(var settings : Settings, private 
         val oldValue = settings.getProperty<Any>(settingString)
 
         val castValue = try {
-            settings.parseType("$value")
+            Settings.parseType("$value")
         } catch (e: NumberFormatException) {
             JOptionPane.showMessageDialog(mainFrame, e.message, "Type Error", JOptionPane.ERROR_MESSAGE)
             return

--- a/src/test/kotlin/microscenery/unit/settings/TypeParsingTest.kt
+++ b/src/test/kotlin/microscenery/unit/settings/TypeParsingTest.kt
@@ -1,0 +1,87 @@
+package microscenery.unit.settings
+
+
+import com.jogamp.common.util.ReflectionUtil.instanceOf
+import fromScenery.Settings
+import org.joml.Vector2f
+import org.joml.Vector3f
+import org.joml.Vector4f
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalArgumentException
+import kotlin.test.assertEquals
+
+class TypeParsingTest {
+
+    @Test
+    fun parseType()
+    {
+        //Ints
+        assertEquals(1, Settings.parseType("1"))
+        assertEquals(1L, Settings.parseType("1l"))
+
+        //Float and double
+        assertEquals(1.0f, Settings.parseType("1.0"))
+        assertEquals(1.0f, Settings.parseType("1.0f"))
+        assertEquals(1.0f, Settings.parseType("1f"))
+
+        //String
+        assertEquals("asd", Settings.parseType("asd"))
+        assertInstanceOf(String::class.java, Settings.parseType("asd"))
+
+        //Bools
+        assertEquals(true, Settings.parseType("True"))
+        assertEquals(true, Settings.parseType("tRuE"))
+        assertEquals(false, Settings.parseType("false"))
+        assertEquals(false, Settings.parseType("FalSE"))
+
+
+        //Vectors
+        val vec2 = Vector2f(1.0f, 1.0f)
+        assertEquals(vec2, Settings.parseType("(1,1)"))
+        assertEquals(vec2, Settings.parseType("(1.0f,1.0f)"))
+        assertEquals(vec2, Settings.parseType("(1, 1.0f)"))
+        assertEquals(vec2, Settings.parseType("(1.0, 1.0f)"))
+        val vec3 = Vector3f(1.0f, 1.0f, 1.0f)
+        assertEquals(vec3, Settings.parseType("(1,1,1)"))
+        assertEquals(vec3, Settings.parseType("(1.0f,1.0f,1.0f)"))
+        assertEquals(vec3, Settings.parseType("(1.0,1.0f,1)"))
+        assertEquals(vec3, Settings.parseType("(1.0, 1.0f,1)"))
+        val vec4 = Vector4f(1.0f, 1.0f, 1.0f, 1.0f)
+        assertEquals(vec4, Settings.parseType("(1,1,1,1)"))
+        assertEquals(vec4, Settings.parseType("(1.0f,1.0f,1.0f,1.0f)"))
+        assertEquals(vec4, Settings.parseType("(1.0,1.0f,1,1.0)"))
+        assertEquals(vec4, Settings.parseType("(1.0, 1.0f,1 ,1.0f)"))
+
+        //Exceptions
+        var formatException = assertThrows<NumberFormatException> {
+            Settings.parseType("(g,1,1,1)")
+        }
+        assertEquals("Wrong type inserted at index 0", formatException.message)
+        formatException = assertThrows {
+            Settings.parseType("(1,g,1,1)")
+        }
+        assertEquals("Wrong type inserted at index 1", formatException.message)
+        formatException = assertThrows {
+            Settings.parseType("(1,1,g,1)")
+        }
+        assertEquals("Wrong type inserted at index 2", formatException.message)
+        formatException = assertThrows {
+            Settings.parseType("(1,1,1,g)")
+        }
+        assertEquals("Wrong type inserted at index 3", formatException.message)
+
+        var argumentException = assertThrows<IllegalArgumentException> {
+            Settings.parseType("(1)")
+        }
+        assertEquals("Too little or too many arguments!", argumentException.message)
+        argumentException = assertThrows {
+            Settings.parseType("(1,1,1,1,1)")
+        }
+        assertEquals("Too little or too many arguments!", argumentException.message)
+
+    }
+
+
+}


### PR DESCRIPTION
Not finished solution for  #9 

To test:
- Run
- Hit T
- - Add Entry name
- - Add 'Vec(value(f) value(f) value(f))' without '' -> f optional
- Hit enter
- Try to change entry ba manipulating the numbers


Need to discuss:
- Format lenght (%.xf)
- General Vector format in the Table
- Global String Localization change to US if possible -> would make code alot simpler

Need still to add after discussion:
- Catch, if user inputs characters other than numbers or f as a value ->(maybe by popup as well, but it is harder to catch)