### PR TITLE
Fixes for publishing along with CHI paper

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,24 @@
 # Microscenery
+
+## Running user studies
+### Requirements
+* JDK of Java 17 or higher installed
+* Protobuf compiler installed (comes with the repository for Windows, needs to be installed for macOS or Linux)
+* SteamVR and a working VR headset set up
+* up-to-date graphics drivers with Vulkan support
+
+### Running studies
+
+The study conditions
+* `Study2DAxon`
+* `Study2DTube`
+* `Study3DAxon`
+* `Study3DTube`
+* `StudyVRAxon`
+* `StudyVRTube`
+
+can be run by invoking `./gradlew [study type]` on the command line, e.g. `./gradlew Study2DAxon`. Position data will be written as CSV to the `spatialLogs` directory, with each new study stored in a timestamped file.
+
 ## Components
 ![](doc/FrontBackEnd.png)
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -10,8 +10,8 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
-    maven("https://maven.scijava.org/content/groups/public")
     maven("https://jitpack.io")
+    maven("https://maven.scijava.org/content/groups/public")
 }
 
 
@@ -22,7 +22,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
     implementation("org.joml:joml:1.10.5")
     if(System.getProperty("os.name").lowercase().contains("mac")) {
-        implementation ("com.google.protobuf:protobuf-java:4.29.1") //current macOS homebrew version
+        implementation ("com.google.protobuf:protobuf-java:4.32.0") //current macOS homebrew version
     } else {
         implementation ("com.google.protobuf:protobuf-java:3.25.3") // I think this one was still compatible with micromanager
     }

--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -28,7 +28,10 @@ dependencies {
 
     implementation("org.slf4j:slf4j-simple:2.0.17")
     implementation(project(":core"))
-    implementation(project(":zenSysConCon"))
+    val withSysCon: String? by project
+    if(withSysCon?.toBoolean() == true) {
+        implementation(project(":zenSysConCon"))
+    }
     implementation(files("../core/manualLib/MMCoreJ.jar"))
 
     implementation("org.yaml:snakeyaml") {
@@ -69,6 +72,17 @@ application{
     mainClass = "microscenery.apps.RemoteSCAPEClientScene"
 }
 
+sourceSets {
+    test {
+        kotlin {
+            val withSysCon: String? by project
+            if(withSysCon?.toBoolean() == false || withSysCon == null) {
+                println("Excluding Zen-based tests")
+                exclude("**/*Zen*.kt")
+            }
+        }
+    }
+}
 
 
 tasks{

--- a/frontend/src/test/kotlin/microscenery/scenes/stageStudy/StudySpatialLogger.kt
+++ b/frontend/src/test/kotlin/microscenery/scenes/stageStudy/StudySpatialLogger.kt
@@ -34,6 +34,7 @@ class StudySpatialLogger(val camera: Camera, val msHub: MicrosceneryHub, file: F
     init {
         val sdf = SimpleDateFormat("yyyy-MM-dd--hh-mm-ss")
         val currentDate = sdf.format(Date())
+        File("./spatialLogs").mkdir()
         val f = file ?: File("spatialLogs/$currentDate.csv")
 
         writer = BufferedWriter(FileWriter(f))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,4 +2,8 @@ rootProject.name = "microscenery"
 
 include("core")
 include("frontend")
-include("zenSysConCon")
+
+val withSysCon: String? by extra
+if (withSysCon?.toBoolean() == true) {
+    include("zenSysConCon")
+}


### PR DESCRIPTION
This PR:
* updates the Readme on how to run user studies
* updates the protobuf version used on macOS to the latest version
* enables the project to compile and run without the SysCon/Zen integration being present (to enable SysCon/Zen integration, compile/run with `-PwithSysCon=true`
* fixes an issue where the non-existance of the `spatialLogs` directory would lead to an exception upon startup